### PR TITLE
Delete unused CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,0 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-# For more info about this file, please see https://docs.github.com/en/enterprise/2.18/user/github/creating-cloning-and-archiving-repositories/about-code-owners
-
-# These owners will be the default owners for everything in
-# all repos in the io500 org.
-*       @adilger @gflofst @gmarkomanolis @johnbent @JulianKunkel


### PR DESCRIPTION
This top-level CODEOWNERS file is not used by anything and can be removed.